### PR TITLE
Feature/login api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,22 +1,30 @@
 import * as S from "./style";
 import { useEffect } from "react";
 import kakaoOauth from "./api/kakaoOauth";
+import googleOauth from "./api/googleOauth";
 
 const KAKAO_BASE_URL = import.meta.env.VITE_KAKAO_BASE_URL;
 const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
 const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 const KAKAO_AUTH_URL = `${KAKAO_BASE_URL}/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code&prompt=login`;
-const GOOGLE_BASE_URL = import.meta.env.VITE_GOOGLE_BASE_URL;
+const GOOGLE_OAUTH_URL = import.meta.env.VITE_GOOGLE_OAUTH_URL;
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 const GOOGLE_REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
-const GOOGLE_AUTH_URL = `${GOOGLE_BASE_URL}?scope=https%3A//www.googleapis.com/auth/drive.metadata.readonly&response_type=token&redirect_uri=${GOOGLE_REDIRECT_URI}&client_id=${GOOGLE_CLIENT_ID}`;
+const GOOGLE_AUTH_URL = `${GOOGLE_OAUTH_URL}&redirect_uri=${GOOGLE_REDIRECT_URI}&client_id=${GOOGLE_CLIENT_ID}`;
 
 const Login = () => {
   const code = new URL(window.location.href).searchParams.get("code") || "";
+  const path = window.location.pathname;
   useEffect(() => {
-    (async () => {
-      await kakaoOauth(code)
-    })();
+    if (code) {
+      (async () => {
+        if (path === "/oauth/kakao") {
+          await kakaoOauth(code);
+        } else {
+          await googleOauth(code);
+        }
+      })();
+    }
   }, [code]);
   return (
     <S.Container>

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,67 +1,22 @@
 import * as S from "./style";
-import axios, { AxiosResponse } from "axios";
 import { useEffect } from "react";
+import kakaoOauth from "./api/kakaoOauth";
 
-const CLIENT_ID = "d59bb3e2ca8b6bd01858bde6cbbe69a4";
-const REDIRECT_URI = "http://localhost:5173/oauth/kakao";
-const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&prompt=login`;
-const grantType = "authorization_code";
+const KAKAO_BASE_URL = import.meta.env.VITE_KAKAO_BASE_URL;
+const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
+const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+const KAKAO_AUTH_URL = `${KAKAO_BASE_URL}/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code&prompt=login`;
+const GOOGLE_BASE_URL = import.meta.env.VITE_GOOGLE_BASE_URL;
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+const GOOGLE_REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
+const GOOGLE_AUTH_URL = `${GOOGLE_BASE_URL}?scope=https%3A//www.googleapis.com/auth/drive.metadata.readonly&response_type=token&redirect_uri=${GOOGLE_REDIRECT_URI}&client_id=${GOOGLE_CLIENT_ID}`;
 
-interface AccessTokenResponse {
-  access_token: string;
-}
-interface KakaoUserProfile {
-  id: number;
-  kakao_account: {
-    profile: {
-      nickname: string;
-    };
-  };
-}
 const Login = () => {
   const code = new URL(window.location.href).searchParams.get("code") || "";
   useEffect(() => {
-    if (code) {
-      if (code) {
-        axios
-          .post<null, AxiosResponse<AccessTokenResponse>>(
-            `https://kauth.kakao.com/oauth/token?grant_type=${grantType}&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&code=${code}`,
-            null,
-            {
-              headers: {
-                "Content-type":
-                  "application/x-www-form-urlencoded;charset=utf-8",
-              },
-            }
-          )
-          .then((res: AxiosResponse<AccessTokenResponse>) => {
-            console.log(res);
-            const { access_token } = res.data;
-            axios
-              .post<null, AxiosResponse<KakaoUserProfile>>(
-                `https://kapi.kakao.com/v2/user/me`,
-                {},
-                {
-                  headers: {
-                    Authorization: `Bearer ${access_token}`,
-                    "Content-type":
-                      "application/x-www-form-urlencoded;charset=utf-8",
-                  },
-                }
-              )
-              .then((res: AxiosResponse<KakaoUserProfile>) => {
-                console.log(res);
-                console.log(res.data.kakao_account.profile.nickname);
-              })
-              .catch((error: unknown) => {
-                console.error("Error fetching user profile:", error);
-              });
-          })
-          .catch((error: unknown) => {
-            console.error("Error fetching access token:", error);
-          });
-      }
-    }
+    (async () => {
+      await kakaoOauth(code)
+    })();
   }, [code]);
   return (
     <S.Container>
@@ -70,11 +25,10 @@ const Login = () => {
         <S.OauthBtn
           className="button_login_google"
           onClick={() => {
-            window.location.href =
-              "https://accounts.google.com/o/oauth2/v2/auth";
+            window.location.href = GOOGLE_AUTH_URL;
           }}
         >
-          <S.LogoIcon path="/oauth/google.png" />
+          <S.LogoIcon src="/oauth/google.png" />
           구글로 로그인
         </S.OauthBtn>
         <S.OauthBtn
@@ -83,7 +37,7 @@ const Login = () => {
             window.location.href = KAKAO_AUTH_URL;
           }}
         >
-          <S.LogoIcon path="/oauth/kakao.png" className="kakao" />
+          <S.LogoIcon src="/oauth/kakao.png" className="kakao" />
           카카오톡으로 로그인
         </S.OauthBtn>
       </S.BtnBox>

--- a/src/pages/login/api/googleOauth.tsx
+++ b/src/pages/login/api/googleOauth.tsx
@@ -1,25 +1,28 @@
 import axios from "axios";
 
-const BASE_URL = import.meta.env.VITE_BASE_URL;
-const AUTH_BASE_URL = import.meta.env.VITE_GOOGLE_BASE_URL;
+const BASE_URL = import.meta.env.VITE_BASE_URL
+const APIS_URL = import.meta.env.VITE_GOOGLE_APIS_URL;
 const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+const CLIENT_PASSWORD = import.meta.env.VITE_GOOGLE_CLIENT_PASSWORD;
 const REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
 
-const googleOauth = () => {
-  
-  return axios
-    .post(AUTH_URL, null, {
-      headers: {
-        "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
-      },
+const googleOauth = async(code: string) => {
+  return await axios
+    .post(APIS_URL, {
+      code: code,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_PASSWORD,
+      redirect_uri: REDIRECT_URI,
+      grant_type: "authorization_code",
     })
     .then((res) => {
+      const { access_token } = res.data;
+      axios.defaults.headers.common["Authorization"] = `Bearer ${access_token}`
       axios.post(
         `${BASE_URL}/oauth/token/refresh-token/wrap-with-cookie`,
         { refreshToken: res.data.refresh_token },
         { withCredentials: true }
       );
-      return res;
     })
     .catch((error: unknown) => {
       console.error("Error fetching access token:", error);

--- a/src/pages/login/api/googleOauth.tsx
+++ b/src/pages/login/api/googleOauth.tsx
@@ -1,0 +1,29 @@
+import axios from "axios";
+
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+const AUTH_BASE_URL = import.meta.env.VITE_GOOGLE_BASE_URL;
+const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+const REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
+
+const googleOauth = () => {
+  
+  return axios
+    .post(AUTH_URL, null, {
+      headers: {
+        "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+      },
+    })
+    .then((res) => {
+      axios.post(
+        `${BASE_URL}/oauth/token/refresh-token/wrap-with-cookie`,
+        { refreshToken: res.data.refresh_token },
+        { withCredentials: true }
+      );
+      return res;
+    })
+    .catch((error: unknown) => {
+      console.error("Error fetching access token:", error);
+    });
+};
+
+export default googleOauth;

--- a/src/pages/login/api/kakaoOauth.tsx
+++ b/src/pages/login/api/kakaoOauth.tsx
@@ -3,11 +3,11 @@ import axios from "axios";
 const BASE_URL = import.meta.env.VITE_BASE_RUL;
 const CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
 const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
-const AUTH_BASE_URL = import.meta.env.VITE_KAKAO_BASE_URL;
+const KAKAO_BASE_URL = import.meta.env.VITE_KAKAO_BASE_URL;
 const grantType = "authorization_code";
 
 const kakaoOauth = async (code: string) => {
-  const AUTH_URL = `${AUTH_BASE_URL}/token?grant_type=${grantType}&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&code=${code}`;
+  const AUTH_URL = `${KAKAO_BASE_URL}/token?grant_type=${grantType}&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&code=${code}`;
   return await axios
     .post(AUTH_URL, null, {
       headers: {

--- a/src/pages/login/api/kakaoOauth.tsx
+++ b/src/pages/login/api/kakaoOauth.tsx
@@ -1,0 +1,31 @@
+import axios from "axios";
+
+const BASE_URL = import.meta.env.VITE_BASE_RUL;
+const CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
+const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+const AUTH_BASE_URL = import.meta.env.VITE_KAKAO_BASE_URL;
+const grantType = "authorization_code";
+
+const kakaoOauth = async (code: string) => {
+  const AUTH_URL = `${AUTH_BASE_URL}/token?grant_type=${grantType}&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&code=${code}`;
+  return await axios
+    .post(AUTH_URL, null, {
+      headers: {
+        "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+      },
+    })
+    .then((res) => {
+      const { access_token } = res.data;
+      axios.defaults.headers.common["Authorization"] = `Bearer ${access_token}`;
+      axios.post(
+        `${BASE_URL}/oauth/token/refresh-token/wrap-with-cookie`,
+        { refreshToken: res.data.refresh_token },
+        { withCredentials: true }
+      );
+      return res.data.access_token;
+    })
+    .catch((error: unknown) => {
+      console.error("Error fetching access token:", error);
+    });
+};
+export default kakaoOauth;

--- a/src/pages/login/style.tsx
+++ b/src/pages/login/style.tsx
@@ -39,8 +39,8 @@ export const OauthBtn = styled.button`
     background-color: #fae100;
   }
 `;
-export const LogoIcon = styled.div<{ path: string }>`
-  background-image: url(${props => props.path});
+export const LogoIcon = styled.div<{ src: string }>`
+  background-image: url(${props => props.src});
   width: 19px;
   height: 18px;
   background-size: contain;


### PR DESCRIPTION
# 소셜 로그인 api 
## 개요 
kakao와 google을 사용해서 회원가입/로그인을 진행할 때 받는 토큰을 처리한다.

참조
[google 공식문서](https://developers.google.com/identity/protocols/oauth2/javascript-implicit-flow?hl=ko)
[google 토큰 처리](https://soda-dev.tistory.com/60)
[kakao 공식문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)

## TODO

- [x] 반응형 디자인에 맞춰서 화면 구현
- [x] 소셜 로그인을 진행하기 위해 필요한 google, kakao 로그인 화면 출력
- [x] kakao 서버에서 토큰 발행 api 구현  
- [x] google 서버에서 토큰 발행 api 구현
- [x] access 토큰 로컬 저장
- [x] refresh 토큰 http-only cookie로 서버에 전송 